### PR TITLE
Remove iteritems() call for Python 3 compatability

### DIFF
--- a/highton/highton.py
+++ b/highton/highton.py
@@ -516,7 +516,7 @@ class Highton(object):
             you dont get only the first 500)
         """
         params = {}
-        for key, value in criteria.iteritems():
+        for key, value in criteria.items():
             params['criteria['+key+']'] = value
         return self._get_object_data(self._get_paged_data('people/search', params=params), Person)
     


### PR DESCRIPTION
See https://wiki.python.org/moin/Python3.0 -> Built-In Changes: ```Remove dict.iteritems(), dict.iterkeys(), and dict.itervalues().
Instead: use dict.items(), dict.keys(), and dict.values() respectively.``` Tested in Python 3.5.2 and 2.7.11. Without this change, search_people() fails in Python 3.