### PR TITLE
Fix PyPI version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![PyPI version](https://badge.fury.io/py/highton.svg)](https://badge.fury.io/py/highton)
+[![PyPI version](https://badge.fury.io/py/Highton.svg)](https://badge.fury.io/py/Highton)
 
 Highton
 ===========


### PR DESCRIPTION
This patch fixes the version badge: capitalization matters.

Thank you for your work! I greatly appreciate Highton.