### PR TITLE
Enable downloading of attachments

### DIFF
--- a/highton/call_mixins/call.py
+++ b/highton/call_mixins/call.py
@@ -13,13 +13,14 @@ class Call(metaclass=ABCMeta):
     # yyyymmddhhmmss
 
     @classmethod
-    def _request(cls, method, endpoint=None, params=None, data=None):
+    def _request(cls, method, endpoint=None, params=None, data=None, endpoint_suffix='.xml'):
         response = requests.request(
             method=method,
-            url='https://{user}.{highrise_url}/{endpoint}.xml'.format(
+            url='https://{user}.{highrise_url}/{endpoint}{endpoint_suffix}'.format(
                 user=HightonSettings.username(),
                 highrise_url=HightonConstants.HIGHRISE_URL,
-                endpoint=endpoint if endpoint else cls.ENDPOINT
+                endpoint=endpoint if endpoint else cls.ENDPOINT,
+                endpoint_suffix=endpoint_suffix
             ),
             headers={'Content-Type': 'application/xml'},
             auth=HTTPBasicAuth(username=HightonSettings.api_key(), password=''),
@@ -30,8 +31,8 @@ class Call(metaclass=ABCMeta):
         return response
 
     @classmethod
-    def _get_request(cls, endpoint=None, params=None):
-        return cls._request(method=HightonConstants.GET, endpoint=endpoint, params=params)
+    def _get_request(cls, endpoint=None, params=None, endpoint_suffix='.xml'):
+        return cls._request(method=HightonConstants.GET, endpoint=endpoint, params=params, endpoint_suffix=endpoint_suffix)
 
     @classmethod
     def _post_request(cls, data, endpoint=None, params=None):

--- a/highton/models/__init__.py
+++ b/highton/models/__init__.py
@@ -4,6 +4,7 @@ from .tag import Tag
 from .party import Party
 from .contact_data import ContactData
 from .address import Address
+from .attachment import Attachment
 from .phone_number import PhoneNumber
 from .twitter_account import TwitterAccount
 from .instant_messenger import InstantMessenger

--- a/highton/models/attachment.py
+++ b/highton/models/attachment.py
@@ -26,4 +26,4 @@ class Attachment(
         super().__init__(**kwargs)
 
     def get(self):
-        return self._get_request(endpoint=f'files/{self.id}', endpoint_suffix='').content
+        return self._get_request(endpoint='files/{}'.format(self.id), endpoint_suffix='').content

--- a/highton/models/attachment.py
+++ b/highton/models/attachment.py
@@ -1,10 +1,12 @@
-from highton.models import HightonModel
-from highton.highton_constants import HightonConstants
+from highton import call_mixins
 from highton import fields
+from highton.highton_constants import HightonConstants
+from highton.models import HightonModel
 
 
 class Attachment(
     HightonModel,
+    call_mixins.Call
 ):
     """
 
@@ -22,3 +24,6 @@ class Attachment(
         self.size = fields.IntegerField(name=HightonConstants.SIZE)
 
         super().__init__(**kwargs)
+
+    def get(self):
+        return self._get_request(endpoint=f'files/{self.id}', endpoint_suffix='').content

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='Highton',
-    version='2.0.5',
+    version='2.1.0',
     license='Apache License 2.0',
     description='A Python library for Highrise',
     long_description='A beautiful Python - Highrise - Wrapper.',


### PR DESCRIPTION
Added a new #get method on the attachment object. To get this to work, there is now a switch on whether to use the pervasive '.xml' suffix on Highrise urls or not.